### PR TITLE
Send Folders and multiple Files as ZIP

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -506,6 +506,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ea22880d78093b0cbe17c89f64a7d457941e65759157ec6cb31a31d652b05e5"
 
 [[package]]
+name = "base64ct"
+version = "1.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b645a089122eccb6111b4f81cbc1a49f5900ac4666bb93ac027feaecf15607bf"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -627,6 +633,27 @@ name = "bytes"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89b2fd2a0dcf38d7971e2194b6b6eebab45ae01067456a7fd93d5547a61b70be"
+
+[[package]]
+name = "bzip2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bdb116a6ef3f6c3698828873ad02c3014b3c85cadb88496095628e3ef1e347f8"
+dependencies = [
+ "bzip2-sys",
+ "libc",
+]
+
+[[package]]
+name = "bzip2-sys"
+version = "0.1.11+1.0.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "736a955f3fa7875102d57c82b8cac37ec45224a07fd32d58f9f7a186b6cd4cdc"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
+]
 
 [[package]]
 name = "cache-padded"
@@ -796,6 +823,12 @@ checksum = "c278839b831783b70278b14df4d45e1beb1aad306c07bb796637de9a0e323e8e"
 dependencies = [
  "crossbeam-utils",
 ]
+
+[[package]]
+name = "constant_time_eq"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "245097e9a4535ee1e3e3931fcfcd55a796a44c643e8596ff6566d68f09b87bbc"
 
 [[package]]
 name = "core-foundation"
@@ -2371,10 +2404,33 @@ dependencies = [
 ]
 
 [[package]]
+name = "password-hash"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7676374caaee8a325c9e7a2ae557f216c5563a171d6997b0ef8a65af35147700"
+dependencies = [
+ "base64ct",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "paste"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d01a5bd0424d00070b0098dd17ebca6f961a959dead1dbcbbbc1d1cd8d3deeba"
+
+[[package]]
+name = "pbkdf2"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "83a0692ec44e4cf1ef28ca317f14f8f07da2d95ec3fa01f86e4467b725e60917"
+dependencies = [
+ "digest 0.10.6",
+ "hmac",
+ "password-hash",
+ "sha2",
+]
 
 [[package]]
 name = "percent-encoding"
@@ -2520,6 +2576,8 @@ dependencies = [
  "single_value_channel",
  "tempfile",
  "thiserror",
+ "walkdir",
+ "zip",
 ]
 
 [[package]]
@@ -4221,6 +4279,56 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
+]
+
+[[package]]
+name = "zip"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0445d0fbc924bb93539b4316c11afb121ea39296f99a3c4c9edad09e3658cdef"
+dependencies = [
+ "aes",
+ "byteorder",
+ "bzip2",
+ "constant_time_eq",
+ "crc32fast",
+ "crossbeam-utils",
+ "flate2",
+ "hmac",
+ "pbkdf2",
+ "sha1 0.10.5",
+ "time",
+ "zstd",
+]
+
+[[package]]
+name = "zstd"
+version = "0.11.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "5.0.2+zstd.1.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
+dependencies = [
+ "libc",
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.7+zstd.1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94509c3ba2fe55294d752b79842c530ccfab760192521df74a081a78d2b3c7f5"
+dependencies = [
+ "cc",
+ "libc",
+ "pkg-config",
 ]
 
 [[package]]

--- a/build.rs
+++ b/build.rs
@@ -1,10 +1,4 @@
-extern crate embed_resource;
-use std::env;
-
 fn main() {
-    let target = env::var("TARGET").unwrap();
-    if target.contains("windows") {
-        // on windows we will set our game icon as icon for the executable
-        embed_resource::compile("build/windows/icon.rc");
-    }
+    #[cfg(windows)]
+    embed_resource::compile("build/windows/icon.rc");
 }

--- a/crates/portal-wormhole/Cargo.toml
+++ b/crates/portal-wormhole/Cargo.toml
@@ -13,3 +13,5 @@ tempfile = "3.3.0"
 thiserror = "1.0.38"
 oneshot = { version = "0.1.5", default-features = false, features = ["std"] }
 lazy_static = "1.4.0"
+zip = "0.6.4"
+walkdir = "2.3.2"

--- a/crates/portal-wormhole/src/error.rs
+++ b/crates/portal-wormhole/src/error.rs
@@ -13,6 +13,10 @@ pub enum PortalError {
     TransferRejected(TransferError),
     #[error(transparent)]
     Io(#[from] std::io::Error),
+    #[error(transparent)]
+    Walkdir(#[from] walkdir::Error),
+    #[error(transparent)]
+    Zip(#[from] zip::result::ZipError),
     #[error("The operation has been canceled")]
     Canceled,
 }

--- a/crates/portal-wormhole/src/lib.rs
+++ b/crates/portal-wormhole/src/lib.rs
@@ -8,6 +8,7 @@ pub use self::error::*;
 mod fs;
 pub mod send;
 mod sync;
+mod temp_zip;
 mod transit;
 
 pub use magic_wormhole::{transit::TransitInfo, Code};

--- a/crates/portal-wormhole/src/send.rs
+++ b/crates/portal-wormhole/src/send.rs
@@ -19,15 +19,16 @@ use std::sync::Arc;
 pub enum SendRequest {
     File(PathBuf),
     Folder(PathBuf),
+    Selection(Vec<PathBuf>),
 }
 
 impl SendRequest {
     pub fn from_paths(paths: Vec<PathBuf>) -> Option<Self> {
-        let first_path = paths.first()?.to_owned();
-        if first_path.is_dir() {
-            Some(SendRequest::Folder(first_path))
-        } else {
-            Some(SendRequest::File(first_path))
+        match paths.len() {
+            0 => None,
+            1 if paths[0].is_dir() => Some(SendRequest::Folder(paths[0].clone())),
+            1 => Some(SendRequest::File(paths[0].clone())),
+            _ => Some(SendRequest::Selection(paths)),
         }
     }
 }
@@ -125,6 +126,7 @@ async fn send_impl(
             )
             .await
         }
+        SendRequest::Selection(_) => todo!(),
     }
 }
 

--- a/crates/portal-wormhole/src/send.rs
+++ b/crates/portal-wormhole/src/send.rs
@@ -1,5 +1,5 @@
 use crate::error::PortalError;
-use crate::temp_zip::pack_folder_as_zip;
+use crate::temp_zip::{pack_folder_as_zip, pack_selection_as_zip};
 use crate::transit::{ProgressHandler, TransitHandler, RELAY_HINTS};
 use crate::{Progress, RequestRepaint};
 use async_std::fs::File;
@@ -129,7 +129,19 @@ async fn send_impl(
             )
             .await
         }
-        SendRequest::Selection(_) => todo!(),
+        SendRequest::Selection(paths) => {
+            let zip = pack_selection_as_zip(&paths)?;
+            send_file(
+                wormhole,
+                zip.path(),
+                // TODO: Use the parent folder name if all paths in the selection share a parent folder
+                OsStr::new("Selection.zip"),
+                progress_handler(transit_info_receiver, report.clone()),
+                transit_handler(transit_info_updater, report),
+                cancel,
+            )
+            .await
+        }
     }
 }
 

--- a/crates/portal-wormhole/src/send.rs
+++ b/crates/portal-wormhole/src/send.rs
@@ -134,7 +134,6 @@ async fn send_impl(
             send_file(
                 wormhole,
                 zip.path(),
-                // TODO: Use the parent folder name if all paths in the selection share a parent folder
                 OsStr::new("Selection.zip"),
                 progress_handler(transit_info_receiver, report.clone()),
                 transit_handler(transit_info_updater, report),
@@ -224,7 +223,6 @@ async fn send_folder(
     transit_handler: impl TransitHandler,
     cancel: impl Future<Output = ()>,
 ) -> Result<(), PortalError> {
-    // TODO: Pack folder before connecting to wormhole
     let zip_archive = pack_folder_as_zip(path)?;
     let mut file_name = path.file_name().unwrap().to_owned();
     file_name.push(".zip");

--- a/crates/portal-wormhole/src/send.rs
+++ b/crates/portal-wormhole/src/send.rs
@@ -71,6 +71,7 @@ pub struct SendingController {
 }
 
 pub enum SendingProgress {
+    Packing,
     Connecting,
     Connected(Code),
     PreparingToSend,
@@ -96,8 +97,10 @@ async fn send_impl(
 ) -> Result<(), PortalError> {
     let (transit_info_receiver, transit_info_updater) = svc::channel();
 
+    report(SendingProgress::Packing);
     let sendable_file = SendableFile::from_send_request(send_request)?;
 
+    report(SendingProgress::Connecting);
     let wormhole = async {
         let (welcome, wormhole_future) = connect().await?;
         report(SendingProgress::Connected(welcome.code));

--- a/crates/portal-wormhole/src/send/request.rs
+++ b/crates/portal-wormhole/src/send/request.rs
@@ -1,0 +1,19 @@
+use std::path::PathBuf;
+
+#[derive(Clone, Debug)]
+pub enum SendRequest {
+    File(PathBuf),
+    Folder(PathBuf),
+    Selection(Vec<PathBuf>),
+}
+
+impl SendRequest {
+    pub fn from_paths(paths: Vec<PathBuf>) -> Option<Self> {
+        match paths.len() {
+            0 => None,
+            1 if paths[0].is_dir() => Some(SendRequest::Folder(paths[0].clone())),
+            1 => Some(SendRequest::File(paths[0].clone())),
+            _ => Some(SendRequest::Selection(paths)),
+        }
+    }
+}

--- a/crates/portal-wormhole/src/send/sendable_file.rs
+++ b/crates/portal-wormhole/src/send/sendable_file.rs
@@ -1,26 +1,33 @@
 use super::SendRequest;
+use crate::sync::CancellationReceiver;
 use crate::temp_zip::{pack_folder_as_zip, pack_selection_as_zip};
 use crate::PortalError;
+use async_std::task::spawn_blocking;
 use std::ffi::{OsStr, OsString};
 use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 
 pub enum SendableFile {
     Path(PathBuf),
-    Temporary(NamedTempFile, OsString),
+    Temporary(OsString, NamedTempFile),
 }
 
 impl SendableFile {
-    pub fn from_send_request(send_request: SendRequest) -> Result<SendableFile, PortalError> {
+    /// Note that cancelling this future may not cancel the background work
+    /// immediately as the packing functions only accept cancellation in between files.
+    pub async fn from_send_request(
+        send_request: SendRequest,
+        cancellation: CancellationReceiver,
+    ) -> Result<SendableFile, PortalError> {
         match send_request {
             SendRequest::File(file_path) => Ok(SendableFile::Path(file_path)),
             SendRequest::Folder(folder_path) => Ok(SendableFile::Temporary(
-                pack_folder_as_zip(&folder_path)?,
                 folder_zip_file_name(&folder_path),
+                spawn_blocking(move || pack_folder_as_zip(&folder_path, &cancellation)).await?,
             )),
             SendRequest::Selection(paths) => Ok(SendableFile::Temporary(
-                pack_selection_as_zip(&paths)?,
                 selection_zip_file_name(&paths),
+                spawn_blocking(move || pack_selection_as_zip(&paths, &cancellation)).await?,
             )),
         }
     }
@@ -28,14 +35,14 @@ impl SendableFile {
     pub fn path(&self) -> &Path {
         match self {
             SendableFile::Path(path) => path,
-            SendableFile::Temporary(file, _) => file.path(),
+            SendableFile::Temporary(_, file) => file.path(),
         }
     }
 
     pub fn file_name(&self) -> &OsStr {
         match self {
             SendableFile::Path(path) => path.file_name().unwrap(),
-            SendableFile::Temporary(_, file_name) => file_name,
+            SendableFile::Temporary(file_name, _) => file_name,
         }
     }
 }

--- a/crates/portal-wormhole/src/send/sendable_file.rs
+++ b/crates/portal-wormhole/src/send/sendable_file.rs
@@ -1,0 +1,73 @@
+use super::SendRequest;
+use crate::temp_zip::{pack_folder_as_zip, pack_selection_as_zip};
+use crate::PortalError;
+use std::ffi::{OsStr, OsString};
+use std::path::{Path, PathBuf};
+use tempfile::NamedTempFile;
+
+pub enum SendableFile {
+    Path(PathBuf),
+    Temporary(NamedTempFile, OsString),
+}
+
+impl SendableFile {
+    pub fn from_send_request(send_request: SendRequest) -> Result<SendableFile, PortalError> {
+        match send_request {
+            SendRequest::File(file_path) => Ok(SendableFile::Path(file_path)),
+            SendRequest::Folder(folder_path) => Ok(SendableFile::Temporary(
+                pack_folder_as_zip(&folder_path)?,
+                folder_zip_file_name(&folder_path),
+            )),
+            SendRequest::Selection(paths) => Ok(SendableFile::Temporary(
+                pack_selection_as_zip(&paths)?,
+                selection_zip_file_name(&paths),
+            )),
+        }
+    }
+
+    pub fn path(&self) -> &Path {
+        match self {
+            SendableFile::Path(path) => path,
+            SendableFile::Temporary(file, _) => file.path(),
+        }
+    }
+
+    pub fn file_name(&self) -> &OsStr {
+        match self {
+            SendableFile::Path(path) => path.file_name().unwrap(),
+            SendableFile::Temporary(_, file_name) => file_name,
+        }
+    }
+}
+
+fn folder_zip_file_name(folder_path: &Path) -> OsString {
+    folder_path
+        .file_name()
+        .map(|p| concat_os_strs(p, ".zip"))
+        .unwrap_or_else(|| OsString::from("Folder.zip"))
+}
+
+fn selection_zip_file_name(paths: &[PathBuf]) -> OsString {
+    common_parent_directory(paths)
+        .and_then(|p| p.file_name())
+        .map(|p| concat_os_strs(p, ".zip"))
+        .unwrap_or_else(|| OsString::from("Selection.zip"))
+}
+
+fn concat_os_strs(a: impl AsRef<OsStr>, b: impl AsRef<OsStr>) -> OsString {
+    let a = a.as_ref();
+    let b = b.as_ref();
+    let mut result = OsString::with_capacity(a.len() + b.len());
+    result.push(a);
+    result.push(b);
+    result
+}
+
+fn common_parent_directory(paths: &[PathBuf]) -> Option<&Path> {
+    let parent = paths.first()?.parent()?;
+    paths
+        .iter()
+        .skip(1)
+        .all(|p| p.parent() == Some(parent))
+        .then_some(parent)
+}

--- a/crates/portal-wormhole/src/sync.rs
+++ b/crates/portal-wormhole/src/sync.rs
@@ -1,5 +1,9 @@
 use oneshot::TryRecvError;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use BorrowingOneshotReceiverState::*;
+
+use crate::PortalError;
 
 pub struct BorrowingOneshotReceiver<T> {
     state: BorrowingOneshotReceiverState<T>,
@@ -44,5 +48,39 @@ impl<T> From<oneshot::Receiver<T>> for BorrowingOneshotReceiver<T> {
             state: BorrowingOneshotReceiverState::Waiting,
             incoming: value,
         }
+    }
+}
+
+pub fn cancellation_pair() -> (CancellationSender, CancellationReceiver) {
+    let canceled = Arc::new(AtomicBool::new(false));
+    (
+        CancellationSender {
+            canceled: canceled.clone(),
+        },
+        CancellationReceiver { canceled },
+    )
+}
+
+pub struct CancellationReceiver {
+    canceled: Arc<AtomicBool>,
+}
+
+impl CancellationReceiver {
+    pub fn propagate(&self) -> Result<(), PortalError> {
+        if self.canceled.load(Ordering::Relaxed) {
+            Err(PortalError::Canceled)
+        } else {
+            Ok(())
+        }
+    }
+}
+
+pub struct CancellationSender {
+    canceled: Arc<AtomicBool>,
+}
+
+impl CancellationSender {
+    pub fn cancel(&self) {
+        self.canceled.store(true, Ordering::Relaxed);
     }
 }

--- a/crates/portal-wormhole/src/temp_zip.rs
+++ b/crates/portal-wormhole/src/temp_zip.rs
@@ -7,7 +7,6 @@ use walkdir::WalkDir;
 use zip::write::FileOptions;
 use zip::ZipWriter;
 
-// TODO: Progress report
 pub fn pack_folder_as_zip(folder_path: &Path) -> Result<NamedTempFile, PortalError> {
     let mut temp_file = NamedTempFile::new()?;
     {
@@ -17,7 +16,6 @@ pub fn pack_folder_as_zip(folder_path: &Path) -> Result<NamedTempFile, PortalErr
     Ok(temp_file)
 }
 
-// TODO: conflict handling
 pub fn pack_selection_as_zip(paths: &[PathBuf]) -> Result<NamedTempFile, PortalError> {
     let mut temp_file = NamedTempFile::new()?;
     {
@@ -46,8 +44,6 @@ where
             .strip_prefix(folder_path)
             .expect("File in folder should start with folder path");
         let relative_path_as_string = relative_path.to_string_lossy();
-
-        // TODO: decide when to enable large_file(true)
 
         if entry.file_type().is_dir() {
             writer.add_directory(relative_path_as_string, FileOptions::default())?;

--- a/crates/portal-wormhole/src/temp_zip.rs
+++ b/crates/portal-wormhole/src/temp_zip.rs
@@ -1,4 +1,5 @@
 use crate::PortalError;
+use std::borrow::Cow;
 use std::fs::File;
 use std::io::{self, Seek, Write};
 use std::path::{Path, PathBuf};
@@ -7,54 +8,101 @@ use walkdir::WalkDir;
 use zip::write::FileOptions;
 use zip::ZipWriter;
 
+/// Packs a folder as a Zip file recursively.
 pub fn pack_folder_as_zip(folder_path: &Path) -> Result<NamedTempFile, PortalError> {
     let mut temp_file = NamedTempFile::new()?;
     {
         let mut writer = ZipWriter::new(&mut temp_file);
-        add_folder_to_zip(folder_path, &mut writer)?;
+        add_folder_to_zip(folder_path, None, &mut writer)?;
     }
     Ok(temp_file)
 }
 
+/// Packs a selection of paths (e.g. from drag and drop) as a Zip file.
 pub fn pack_selection_as_zip(paths: &[PathBuf]) -> Result<NamedTempFile, PortalError> {
     let mut temp_file = NamedTempFile::new()?;
     {
         let mut writer = ZipWriter::new(&mut temp_file);
         for path in paths {
-            if path.is_dir() {
-                add_folder_to_zip(path, &mut writer)?;
-            } else if path.is_file() {
-                add_file_to_zip(path, Path::new(path.file_name().unwrap()), &mut writer)?;
-            } else if path.is_symlink() {
-                todo!()
-            }
+            add_path_to_zip(path, None, &mut writer)?;
         }
     }
     Ok(temp_file)
 }
 
-fn add_folder_to_zip<W>(folder_path: &Path, writer: &mut ZipWriter<W>) -> Result<(), PortalError>
+/// Adds a file or folder to the Zip file.
+///
+/// Symbolic links are materialized (i.e. resolved and the real files or folders are added to the Zip file).
+fn add_path_to_zip<W>(
+    path: &Path,
+    relative_path: Option<&Path>,
+    writer: &mut ZipWriter<W>,
+) -> Result<(), PortalError>
 where
     W: Write + Seek,
 {
-    for entry in WalkDir::new(folder_path) {
+    let relative_path = relative_path.unwrap_or_else(|| Path::new(path.file_name().unwrap()));
+
+    if path.is_dir() {
+        add_folder_to_zip(path, Some(relative_path), writer)?;
+    } else if path.is_file() {
+        add_file_to_zip(path, relative_path, writer)?;
+    } else if path.is_symlink() {
+        add_path_to_zip(&std::fs::read_link(path)?, Some(relative_path), writer)?;
+    } else {
+        unreachable!("Path is either a file, a directory or a symlink");
+    }
+
+    Ok(())
+}
+
+/// Adds a folder to the Zip file by recursively walking through the directory.
+///
+/// Symbolic links are materialized (i.e. resolved and the real files are added to the Zip file). \
+/// This is the default behaviour of the `zip` tool and best for cross-platform compatibility.
+fn add_folder_to_zip<W>(
+    folder_path: &Path,
+    folder_relative_path: Option<&Path>,
+    writer: &mut ZipWriter<W>,
+) -> Result<(), PortalError>
+where
+    W: Write + Seek,
+{
+    for entry in WalkDir::new(folder_path).follow_links(true) {
         let entry = entry?;
-        let relative_path = entry
-            .path()
-            .strip_prefix(folder_path)
-            .expect("File in folder should start with folder path");
+        let relative_path =
+            relative_path_for_entry_in_folder(folder_path, folder_relative_path, entry.path());
         let relative_path_as_string = relative_path.to_string_lossy();
 
         if entry.file_type().is_dir() {
             writer.add_directory(relative_path_as_string, FileOptions::default())?;
         } else if entry.file_type().is_file() {
-            add_file_to_zip(entry.path(), relative_path, writer)?;
-        } else if entry.path_is_symlink() {
-            todo!()
+            add_file_to_zip(entry.path(), &relative_path, writer)?;
+        } else {
+            unreachable!("The file is either a file or directory. Symlinks have been be materialized by .follow_links(true)");
         }
     }
 
     Ok(())
+}
+
+fn relative_path_for_entry_in_folder<'a>(
+    folder_path: &'a Path,
+    folder_relative_path: Option<&'a Path>,
+    entry_path: &'a Path,
+) -> Cow<'a, Path> {
+    let relative_path = entry_path
+        .strip_prefix(folder_path)
+        .expect("File in folder should start with folder path");
+    match folder_relative_path {
+        None => Cow::Borrowed(relative_path),
+        Some(folder_relative_path) => {
+            let mut combined_path = PathBuf::new();
+            combined_path.push(folder_relative_path);
+            combined_path.push(relative_path);
+            Cow::Owned(combined_path)
+        }
+    }
 }
 
 fn add_file_to_zip<W>(

--- a/crates/portal-wormhole/src/temp_zip.rs
+++ b/crates/portal-wormhole/src/temp_zip.rs
@@ -1,7 +1,7 @@
 use crate::PortalError;
 use std::fs::File;
 use std::io::{self, Seek, Write};
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use tempfile::NamedTempFile;
 use walkdir::WalkDir;
 use zip::write::FileOptions;
@@ -10,16 +10,35 @@ use zip::ZipWriter;
 // TODO: Progress report
 pub fn pack_folder_as_zip(folder_path: &Path) -> Result<NamedTempFile, PortalError> {
     let mut temp_file = NamedTempFile::new()?;
-    add_folder_to_zip(folder_path, &mut temp_file)?;
+    {
+        let mut writer = ZipWriter::new(&mut temp_file);
+        add_folder_to_zip(folder_path, &mut writer)?;
+    }
     Ok(temp_file)
 }
 
-fn add_folder_to_zip<W>(folder_path: &Path, write: &mut W) -> Result<(), PortalError>
+// TODO: conflict handling
+pub fn pack_selection_as_zip(paths: &[PathBuf]) -> Result<NamedTempFile, PortalError> {
+    let mut temp_file = NamedTempFile::new()?;
+    {
+        let mut writer = ZipWriter::new(&mut temp_file);
+        for path in paths {
+            if path.is_dir() {
+                add_folder_to_zip(path, &mut writer)?;
+            } else if path.is_file() {
+                add_file_to_zip(path, Path::new(path.file_name().unwrap()), &mut writer)?;
+            } else if path.is_symlink() {
+                todo!()
+            }
+        }
+    }
+    Ok(temp_file)
+}
+
+fn add_folder_to_zip<W>(folder_path: &Path, writer: &mut ZipWriter<W>) -> Result<(), PortalError>
 where
     W: Write + Seek,
 {
-    let mut writer = ZipWriter::new(write);
-
     for entry in WalkDir::new(folder_path) {
         let entry = entry?;
         let relative_path = entry
@@ -33,13 +52,25 @@ where
         if entry.file_type().is_dir() {
             writer.add_directory(relative_path_as_string, FileOptions::default())?;
         } else if entry.file_type().is_file() {
-            writer.start_file(relative_path_as_string, FileOptions::default())?;
-            let mut reader = File::open(entry.path())?;
-            io::copy(&mut reader, &mut writer)?;
+            add_file_to_zip(entry.path(), relative_path, writer)?;
         } else if entry.path_is_symlink() {
             todo!()
         }
     }
 
+    Ok(())
+}
+
+fn add_file_to_zip<W>(
+    source_path: &Path,
+    relative_path: &Path,
+    writer: &mut ZipWriter<W>,
+) -> Result<(), PortalError>
+where
+    W: Write + Seek,
+{
+    writer.start_file(relative_path.to_string_lossy(), FileOptions::default())?;
+    let mut reader = File::open(source_path)?;
+    io::copy(&mut reader, writer)?;
     Ok(())
 }

--- a/crates/portal-wormhole/src/temp_zip.rs
+++ b/crates/portal-wormhole/src/temp_zip.rs
@@ -1,0 +1,45 @@
+use crate::PortalError;
+use std::fs::File;
+use std::io::{self, Seek, Write};
+use std::path::Path;
+use tempfile::NamedTempFile;
+use walkdir::WalkDir;
+use zip::write::FileOptions;
+use zip::ZipWriter;
+
+// TODO: Progress report
+pub fn pack_folder_as_zip(folder_path: &Path) -> Result<NamedTempFile, PortalError> {
+    let mut temp_file = NamedTempFile::new()?;
+    add_folder_to_zip(folder_path, &mut temp_file)?;
+    Ok(temp_file)
+}
+
+fn add_folder_to_zip<W>(folder_path: &Path, write: &mut W) -> Result<(), PortalError>
+where
+    W: Write + Seek,
+{
+    let mut writer = ZipWriter::new(write);
+
+    for entry in WalkDir::new(folder_path) {
+        let entry = entry?;
+        let relative_path = entry
+            .path()
+            .strip_prefix(folder_path)
+            .expect("File in folder should start with folder path");
+        let relative_path_as_string = relative_path.to_string_lossy();
+
+        // TODO: decide when to enable large_file(true)
+
+        if entry.file_type().is_dir() {
+            writer.add_directory(relative_path_as_string, FileOptions::default())?;
+        } else if entry.file_type().is_file() {
+            writer.start_file(relative_path_as_string, FileOptions::default())?;
+            let mut reader = File::open(entry.path())?;
+            io::copy(&mut reader, &mut writer)?;
+        } else if entry.path_is_symlink() {
+            todo!()
+        }
+    }
+
+    Ok(())
+}

--- a/crates/portal-wormhole/src/temp_zip.rs
+++ b/crates/portal-wormhole/src/temp_zip.rs
@@ -19,6 +19,9 @@ pub fn pack_folder_as_zip(folder_path: &Path) -> Result<NamedTempFile, PortalErr
 }
 
 /// Packs a selection of paths (e.g. from drag and drop) as a Zip file.
+///
+/// Note that this function does not handle duplicate entries as this should be a rare case
+/// (it requires selecting files across multiple directories).
 pub fn pack_selection_as_zip(paths: &[PathBuf]) -> Result<NamedTempFile, PortalError> {
     let mut temp_file = NamedTempFile::new()?;
     {

--- a/src/send.rs
+++ b/src/send.rs
@@ -144,6 +144,7 @@ fn show_transfer_progress(
     }
 
     match controller.progress() {
+        SendingProgress::Packing => show_packing_progress(ui, send_request),
         SendingProgress::Connecting => show_transmit_code_progress(ui),
         SendingProgress::Connected(code) => show_transmit_code(ui, code, send_request),
         SendingProgress::PreparingToSend => page_with_content(
@@ -171,6 +172,21 @@ fn show_transfer_progress(
             )
         }
     }
+}
+
+fn show_packing_progress(ui: &mut Ui, send_request: &SendRequest) {
+    page_with_content(
+        ui,
+        "Send File",
+        format!(
+            "Packing {} to a Zip file...",
+            SendRequestDisplay(send_request)
+        ),
+        "📤",
+        |ui| {
+            ui.spinner();
+        },
+    )
 }
 
 fn show_transmit_code_progress(ui: &mut Ui) {

--- a/src/send.rs
+++ b/src/send.rs
@@ -74,8 +74,11 @@ impl SendView {
         if ui.add(select_file_button).clicked()
             || ui.input_mut(|input| input.consume_key(Modifiers::COMMAND, Key::O))
         {
-            if let Some(file_path) = FileDialog::new().pick_file() {
-                *self = SendView::new_sending(ui, SendRequest::File(file_path))
+            if let Some(send_request) = FileDialog::new()
+                .pick_files()
+                .and_then(SendRequest::from_paths)
+            {
+                *self = SendView::new_sending(ui, send_request)
             }
         }
 
@@ -83,8 +86,11 @@ impl SendView {
 
         let select_folder_button = Button::new("Select Folder").min_size(MIN_BUTTON_SIZE);
         if ui.add(select_folder_button).clicked() {
-            if let Some(folder_path) = FileDialog::new().pick_folder() {
-                *self = SendView::new_sending(ui, SendRequest::Folder(folder_path))
+            if let Some(send_request) = FileDialog::new()
+                .pick_folders()
+                .and_then(SendRequest::from_paths)
+            {
+                *self = SendView::new_sending(ui, send_request)
             }
         }
     }

--- a/src/send.rs
+++ b/src/send.rs
@@ -212,6 +212,7 @@ impl<'a> fmt::Display for SendRequestDisplay<'a> {
             SendRequest::Folder(path) => {
                 write!(f, "folder \"{}\"", filename_or_self(path).display())
             }
+            SendRequest::Selection(_) => write!(f, "selection"),
         }
     }
 }


### PR DESCRIPTION
Resolves #16
Resolves #8

## Todo
* [x] Use the parent folder name for selection's ZIP file name if all paths in the selection share a parent folder
* [x] Pack ZIP before connecting to wormhole
* [x] Report progress when packing ZIP (moved into separate issue #23)
* [x] Handle conflicts between multiple files with the same name when packing a selection of files
* [x] Decide when to enable `large_file(true)`
* [x] Decide what to do with symlinks
* [x] Make ZIP packing cancelable